### PR TITLE
feat: local‑time emails & past‑hour lockout in booking UI

### DIFF
--- a/appointments/forms.py
+++ b/appointments/forms.py
@@ -100,9 +100,9 @@ class CitaForm(forms.ModelForm):
         dia = raw.date() if isinstance(raw, datetime) else raw
 
         if dia.weekday() >= 5:
-            raise forms.ValidationError("¡El finde no curro!")
+            raise forms.ValidationError("¡El finde no curro mi niño!")
         if dia < timezone.localdate():
-            raise forms.ValidationError("La fecha ya pasó.")
+            raise forms.ValidationError("La fecha ya pasó puntal.")
 
         # Build aware datetime at midnight in current TZ
         dt_midnight = datetime.combine(dia, time.min)
@@ -118,7 +118,8 @@ class CitaForm(forms.ModelForm):
 
         if not time(9, 30) <= hora <= time(19, 30):
             raise forms.ValidationError("Hora fuera de rango.")
-        return hora  # clean time
+        return hora
+    
 
 
 # Autor / Licencia: José Félix Gordo Castaño — Uso educativo, no comercial

--- a/appointments/views.py
+++ b/appointments/views.py
@@ -262,10 +262,11 @@ def eliminar_cita(request, cita_id):
 
     if request.method == 'POST':
         cita_detalle = {
-            'email': request.user.email,
+            'usuario' : request.user.get_full_name() or request.user.username,
+            'email'   : request.user.email,
             'servicio': cita.servicio.nombre,
-            'fecha': cita.fecha,
-            'hora': cita.hora
+            'fecha'   : cita.fecha,
+            'hora'    : cita.hora,
         }
         
         cita.delete()

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,28 +1,50 @@
 from django.core.mail import send_mail
 from django.conf import settings
+from django.utils import timezone
+
+
+# ──────────────────────────────────────────────────────────────
+def _formatear_fecha_hora(dt):
+    """
+    Convierte un DateTimeField (aware o UTC) a la zona Atlantic/Canary
+    y devuelve una tupla (dd/mm/aaaa, HH:MM).
+    """
+    local = timezone.localtime(dt)
+    return local.strftime("%d/%m/%Y"), local.strftime("%H:%M")
+# ──────────────────────────────────────────────────────────────
 
 
 def enviar_correo_admin(asunto, mensaje):
-    """
-    Envía un correo electrónico a los administradores configurados en settings.ADMINS.
-    """
+    """Envía un correo electrónico a los administradores definidos en settings.ADMINS."""
     if settings.ADMINS:
         admin_emails = [admin[1] for admin in settings.ADMINS]
-        send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, admin_emails, fail_silently=False)
+        send_mail(
+            asunto,
+            mensaje,
+            settings.EMAIL_HOST_USER,
+            admin_emails,
+            fail_silently=False,
+        )
 
+
+# ══════════════════════════════════════════════════════════════
+# 1) CONFIRMACIÓN DE NUEVA CITA
+# ══════════════════════════════════════════════════════════════
 def enviar_confirmacion_cita(usuario_email, cita):
-    asunto = 'Confirmación de tu cita en Ca´Bigote Barber Shop'
+    fecha_str, hora_str = _formatear_fecha_hora(cita.fecha)
+
+    asunto = "Confirmación de tu cita en Ca´Bigote Barber Shop"
     mensaje = f"""
     Estimado usuario,
 
     Gracias por reservar una cita con nosotros. Aquí están los detalles de tu cita:
 
-    Servicio: {cita.servicio.nombre}
-    Fecha: {cita.fecha}
-    Hora: {cita.hora}
-    Comentario: {cita.comentario}
+    Servicio : {cita.servicio.nombre}
+    Fecha    : {fecha_str}
+    Hora     : {hora_str}
+    Comentario: {cita.comentario or 'Sin comentarios'}
 
-    En caso de no poder asistir, puede editar su cita desde nuestra app!
+    En caso de no poder asistir, puedes editar tu cita desde nuestra app.
 
     ¡Te esperamos!
 
@@ -32,31 +54,38 @@ def enviar_confirmacion_cita(usuario_email, cita):
     ---
 
     Dirección: calle el rafael 43, Arrecife
-    Teléfono: +34 699 85 99 61
+    Teléfono : +34 699 85 99 61
     ¡Síguenos para más novedades!
     """
-    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email], fail_silently=False)
+    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email])
 
     # Notificar a los administradores
     mensaje_admin = f"""Un usuario ha reservado una cita:
 
-    Usuario: {cita.usuario.username if hasattr(cita, 'usuario') else 'Usuario no disponible'}
-    Comentario: {cita.comentario if cita.comentario else 'Sin comentarios'}
+    Usuario    : {getattr(cita.usuario, 'username', 'Usuario no disponible')}
+    Comentario : {cita.comentario or 'Sin comentarios'}
 
-    Servicio: {cita.servicio.nombre}
-    Fecha: {cita.fecha}
-    Hora: {cita.hora}
+    Servicio : {cita.servicio.nombre}
+    Fecha    : {fecha_str}
+    Hora     : {hora_str}
     """
-    enviar_correo_admin('Nueva cita reservada en Ca´Bigote', mensaje_admin)
+    enviar_correo_admin("Nueva cita reservada en Ca´Bigote", mensaje_admin)
 
+
+# ══════════════════════════════════════════════════════════════
+# 2) NOTIFICACIÓN DE ELIMINACIÓN
+# ══════════════════════════════════════════════════════════════
 def enviar_notificacion_eliminacion_cita(usuario_email, cita_detalle):
-    asunto = 'Tu cita en Ca´Bigote Barber Shop ha sido eliminada'
+    fecha_str, hora_str = _formatear_fecha_hora(cita_detalle["fecha"])
+
+    asunto = "Tu cita en Ca´Bigote Barber Shop ha sido eliminada"
     mensaje = f"""
     Estimado usuario,
 
-    Tu cita para el servicio {cita_detalle['servicio']} el {cita_detalle['fecha']} a las {cita_detalle['hora']} ha sido eliminada correctamente.
+    Tu cita para el servicio {cita_detalle['servicio']}
+    el {fecha_str} a las {hora_str} ha sido eliminada correctamente.
 
-    Si deseas, puedes volver a agendar una cita desde nuestra aplicación.
+    Si lo deseas, puedes volver a agendar una cita desde nuestra aplicación.
 
     Atentamente,
     Ca´Bigote Barber Shop
@@ -64,34 +93,40 @@ def enviar_notificacion_eliminacion_cita(usuario_email, cita_detalle):
     ---
 
     Dirección: calle el rafael 43, Arrecife
-    Teléfono: +34 699 85 99 61
+    Teléfono : +34 699 85 99 61
     ¡Síguenos para más novedades!
     """
-    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email], fail_silently=False)
+    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email])
 
     # Notificar a los administradores
     mensaje_admin = f"""Un usuario ha eliminado una cita:
 
-    Usuario: {cita_detalle['usuario'] if 'usuario' in cita_detalle else 'Usuario no disponible'}
-    Comentario: {cita_detalle['comentario'] if 'comentario' in cita_detalle else 'Sin comentarios'}
+    Usuario    : {cita_detalle.get('usuario', 'Usuario no disponible')}
+    Comentario : {cita_detalle.get('comentario', 'Sin comentarios')}
 
-    Servicio: {cita_detalle['servicio']}
-    Fecha: {cita_detalle['fecha']}
-    Hora: {cita_detalle['hora']}
+    Servicio : {cita_detalle['servicio']}
+    Fecha    : {fecha_str}
+    Hora     : {hora_str}
     """
-    enviar_correo_admin('Cita eliminada en Ca´Bigote', mensaje_admin)
+    enviar_correo_admin("Cita eliminada en Ca´Bigote", mensaje_admin)
 
+
+# ══════════════════════════════════════════════════════════════
+# 3) NOTIFICACIÓN DE MODIFICACIÓN
+# ══════════════════════════════════════════════════════════════
 def enviar_notificacion_modificacion_cita(usuario_email, cita):
-    asunto = 'Tu cita en Ca´Bigote Barber Shop ha sido modificada'
+    fecha_str, hora_str = _formatear_fecha_hora(cita.fecha)
+
+    asunto = "Tu cita en Ca´Bigote Barber Shop ha sido modificada"
     mensaje = f"""
     Estimado usuario,
 
     Tu cita ha sido modificada. Aquí están los nuevos detalles:
 
-    Servicio: {cita.servicio.nombre}
-    Nueva fecha: {cita.fecha}
-    Nueva hora: {cita.hora}
-    Comentario: {cita.comentario}
+    Servicio : {cita.servicio.nombre}
+    Nueva fecha : {fecha_str}
+    Nueva hora  : {hora_str}
+    Comentario  : {cita.comentario or 'Sin comentarios'}
 
     Atentamente,
     Ca´Bigote Barber Shop
@@ -99,37 +134,43 @@ def enviar_notificacion_modificacion_cita(usuario_email, cita):
     ---
 
     Dirección: calle el rafael 43, Arrecife
-    Teléfono: +34 699 85 99 61
+    Teléfono : +34 699 85 99 61
     ¡Síguenos para más novedades!
     """
-    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email], fail_silently=False)
+    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email])
 
     # Notificar a los administradores
     mensaje_admin = f"""Un usuario ha modificado una cita:
 
-    Usuario: {cita.usuario.username if cita.usuario else 'Usuario no disponible'}
-    Comentario: {cita.comentario if cita.comentario else 'Sin comentarios'}
+    Usuario    : {getattr(cita.usuario, 'username', 'Usuario no disponible')}
+    Comentario : {cita.comentario or 'Sin comentarios'}
 
-    Servicio: {cita.servicio.nombre}
-    Nueva fecha: {cita.fecha}
-    Nueva hora: {cita.hora}
+    Servicio : {cita.servicio.nombre}
+    Nueva fecha : {fecha_str}
+    Nueva hora  : {hora_str}
     """
-    enviar_correo_admin('Cita modificada en Ca´Bigote', mensaje_admin)
+    enviar_correo_admin("Cita modificada en Ca´Bigote", mensaje_admin)
 
 
+# ══════════════════════════════════════════════════════════════
+# 4) RECORDATORIO (sin cambios de lógica, sólo formateo)
+# ══════════════════════════════════════════════════════════════
 def enviar_recordatorio_cita(usuario_email, cita):
-    asunto = 'Recordatorio de tu cita en Ca´Bigote Barber Shop'
+    fecha_str, hora_str = _formatear_fecha_hora(cita.fecha)
+
+    asunto = "Recordatorio de tu cita en Ca´Bigote Barber Shop"
     mensaje = f"""
     Estimado usuario,
 
     Te recordamos que tienes una cita programada para mañana:
 
-    Servicio: {cita.servicio.nombre}
-    Fecha: {cita.fecha}
-    Hora: {cita.hora}
-    Comentario: {cita.comentario if cita.comentario else 'Sin comentarios'}
+    Servicio : {cita.servicio.nombre}
+    Fecha    : {fecha_str}
+    Hora     : {hora_str}
+    Comentario: {cita.comentario or 'Sin comentarios'}
 
-    Por favor, asegúrate de llegar a tiempo. Si no puedes asistir, recuerda que puedes modificar tu cita desde nuestra app web.
+    Por favor, asegúrate de llegar a tiempo.  
+    Si no puedes asistir, recuerda que puedes modificar tu cita desde nuestra app web.
 
     ¡Te esperamos!
 
@@ -137,11 +178,10 @@ def enviar_recordatorio_cita(usuario_email, cita):
     Ca´Bigote Barber Shop
 
     Dirección: calle el rafael 43, Arrecife
-    Teléfono: +34 699 85 99 61
+    Teléfono : +34 699 85 99 61
     """
-    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email], fail_silently=False)
+    send_mail(asunto, mensaje, settings.EMAIL_HOST_USER, [usuario_email])
+
 
 # Autor: José Félix Gordo Castaño
-# Copyright (C) 2024 José Félix Gordo Castaño
-# Este archivo está licenciado para uso exclusivo con fines educativos y de aprendizaje. 
-# No se permite la venta ni el uso comercial sin autorización expresa del autor.
+# Licencia: Uso educativo, no comercial

--- a/static/js/disableDates.js
+++ b/static/js/disableDates.js
@@ -39,25 +39,61 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     if (inputFecha) {
-        // Call the function to update occupied hours on initial load
+      
+    // 1) Llama una vez al cargar
+    // ──────────────────────────────────────────────────────────
+    updateOccupiedHours();
+
+    // ──────────────────────────────────────────────────────────
+    // 2) Listener: al enfocar el campo fecha
+    // ──────────────────────────────────────────────────────────
+    inputFecha.addEventListener('focus', () => {
+    // Normalizamos listas a YYYY‑MM‑DD
+    const reservedDates = fechasOcupadas.map(
+        f => new Date(f).toISOString().split('T')[0]
+    );
+    const blockedDates = fechasBloqueadas.map(
+        f => new Date(f).toISOString().split('T')[0]
+    );
+
+    // ───── Listener interno: cada vez que cambia la fecha ─────
+    inputFecha.addEventListener('input', () => {
+        const selectedDate = inputFecha.value;
+
+        if (blockedDates.includes(selectedDate)) {
+        alert("¡Estás bonito! Te recuerdo que este día no curro niñote.");
+        inputFecha.value = '';
+        return;
+        }
+
+        if (reservedDates.includes(selectedDate)) {
+        alert("¡Chacho loco! La fecha seleccionada está completamente reservada.");
+        inputFecha.value = '';
+        return;
+        }
+
+        // Fecha válida → actualizamos horas
         updateOccupiedHours();
 
-        inputFecha.addEventListener('focus', () => {
-            const reservedDates = fechasOcupadas.map(fecha => new Date(fecha).toISOString().split('T')[0]);
-            const blockedDates = fechasBloqueadas.map(fecha => new Date(fecha).toISOString().split('T')[0]);
+        /* ────────────────────────────────────────────────
+        3) Si la fecha es hoy, deshabilita horas pasadas
+        ──────────────────────────────────────────────── */
+        const hoyISO = new Date().toISOString().split('T')[0];
 
-            inputFecha.addEventListener('input', () => {
-                const selectedDate = inputFecha.value;
-                if (blockedDates.includes(selectedDate)) {
-                    alert("¡Estás bonito! Te recuerdo que este día no curro niñote.");
-                    inputFecha.value = '';
-                } else if (reservedDates.includes(selectedDate)) {
-                    alert("¡Chacho loco! La fecha seleccionada está completamente reservada.");
-                    inputFecha.value = '';
-                } else {
-                    updateOccupiedHours();
-                }
+        if (selectedDate === hoyISO) {
+        const ahora = new Date();
+
+        Array.from(inputHora.options).forEach(opt => {
+            if (!opt.value) return;            
+            const [h, m] = opt.value.split(':').map(Number);
+            const optDate = new Date();
+            optDate.setHours(h, m, 0, 0);
+
+            // Desactiva si la hora ya ocurrió
+            if (optDate <= ahora) opt.disabled = true;
             });
+          }
         });
-    }
-});
+      });   
+    }  
+  });         

--- a/templates/admin/custom_index.html
+++ b/templates/admin/custom_index.html
@@ -39,8 +39,8 @@
   </div>
 
   <div class="button-row">
-    <a href="{% url 'admin:descargar_reporte' %}" class="button btn-admin-action">📥 Descargar Informe</a>
-    <a href="{% url 'admin:appointments_cita_changelist' %}" class="button btn-admin-action">👁️ Ver Citas</a>
+    <a href="{% url 'admin:descargar_reporte' %}" class="button btn-admin-action">📥 Informe</a>
+    <a href="{% url 'admin:appointments_cita_changelist' %}" class="button btn-admin-action">👁️ Citas</a>
     <a href="{% url 'admin:auth_user_changelist' %}" class="button btn-admin-action">👤 Usuarios</a>
   </div>
 


### PR DESCRIPTION
* core/utils.py
  • Add `_formatear_fecha_hora()` helper → converts any aware/UTC DateTime to
    Atlantic/Canary and returns “dd/mm/yyyy, HH:MM”.
  • Use the helper in all mailers (`enviar_confirmacion_cita`,
    `enviar_notificacion_modificacion_cita`, `enviar_notificacion_eliminacion_cita`,
    `enviar_recordatorio_cita`) to replace raw `str(cita.fecha)` / `cita.hora`.
  • Emails now show consistent local dates & times (no more “+00:00 / +01:00”).

* static/js/disableDates.js
  • On DOM ready, run `updateOccupiedHours()` once for initial state.
  • Inside the `input` handler, if selected date is *today* disable any `<option>`
    whose time is earlier than the current moment.
  • Keeps existing logic for occupied and blocked hours.