### PR TITLE
feat(consent): modal first layer, improved panel, thirdparty gating f…

### DIFF
--- a/cabigote/settings.py
+++ b/cabigote/settings.py
@@ -385,9 +385,10 @@ CONTENT_SECURITY_POLICY = {
         ),
 
         # Proteger contra clickjacking
-        "frame-ancestors": ("'self'",),
+        "frame-ancestors": ("'self'",), 
     }
 }
+
 
 # REDIS RAILWAY CACHE CONFIG
 CACHES = {
@@ -398,11 +399,12 @@ CACHES = {
     }
 }
 
+
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 SESSION_COOKIE_AGE = 7 * 24 * 60 * 60
 
 
 # APP VERSION
-APP_VERSION = "2.6.5"
+APP_VERSION = "2.6.7"
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -44,9 +44,9 @@
     <link rel="icon" type="image/x-icon" href="{% static 'imagenes/favicon.ico' %}">
     <link rel="apple-touch-icon" sizes="180x180" href="{% static 'imagenes/logo-cb.jpg' %}">
 
-    <!-- Bootstrap CSS -->
-    <link rel="dns-prefetch" href="//stackpath.bootstrapcdn.com">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Bootstrap CSS (v5) -->
+    <link rel="dns-prefetch" href="//cdn.jsdelivr.net">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom Styles -->
     <link rel="preload" href="{% static 'css/styles.css' %}" as="style">
@@ -72,47 +72,6 @@
         <div id="overlay" class="overlay"></div>
         <!-- Loading spinner -->
         <div id="loader" class="visible"></div>
-
-        <!-- Cookie modal -->
-        <div class="modal fade" id="cookiesModal" tabindex="-1" role="dialog" aria-labelledby="cookiesModalLabel" inert aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="cookiesModalLabel">Política de Cookies</h5>
-                    </div>
-                    <div class="modal-body">
-                        <p>Este sitio utiliza cookies para mejorar su experiencia. Al continuar navegando, aceptas el uso de cookies. Puedes encontrar más información en nuestra <a href="#" id="privacyPolicyLink">política de privacidad</a>.</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button id="rejectCookiesBtn" class="btn btn-outline-secondary" data-bs-dismiss="modal">Rechazar</button>
-                        <button id="acceptCookiesBtn" class="btn btn-primary">Aceptar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- POLICY -->
-        <div class="modal fade" id="privacyPolicyModal" tabindex="-1" role="dialog" aria-labelledby="privacyPolicyModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="privacyPolicyModalLabel">Política de Privacidad</h5>
-                    </div>
-                    <div class="modal-body">
-                        <p> Política de Privacidad<br>
-                            En Cabigote, nos comprometemos a proteger la privacidad de nuestros usuarios y a cumplir con las leyes y regulaciones aplicables en materia de protección de datos personales.
-                        </p>
-                            <br>
-                        <p>
-                            Uso de Cookies<br>
-                            Nuestro sitio web utiliza cookies para mejorar su experiencia de navegación y recopilar información sobre su actividad en la página web. Las cookies son archivos de texto o paquetes de datos que se almacenan en su navegador y que nos permiten recopilar información sobre su visita, como la fecha y hora de acceso, el tipo de navegador y sistema operativo utilizado.. 
-                        </p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cerrar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
 
         <div class="d-flex flex-column min-vh-100">  
             <header>
@@ -241,85 +200,276 @@
                 <!-- CONTENT TEMPLATES -->
                 {% endblock %}
             </main>
+
             <footer class="primary-color text-white-50 py-4">
-                <div class="container">
-                    <div class="row">
-                        <!-- ABOUT -->
-                        <div class="col-md-4">
-                            <h5 class="text-white text-center">Sobre Nosotros</h5>
-                            <p>Ca'Bigote es una barbería moderna con un toque clásico. Nos dedicamos a ofrecer los mejores cortes y afeitados con la mejor atención al cliente.</p>
-                        </div>
-            
-                        <!-- ACTIONS -->
-                        <div class="col-md-4">
-                            <h5 class="text-white">Enlaces Rápidos</h5>
-                            <ul class="list-unstyled">
-                                <li><a href="{% url 'home' %}" class="text-white-50">Inicio</a></li>
-                                <li><a href="{% url 'services:ver_servicios' %}" class="text-white-50">Servicios</a></li>
-                                <li><a href="{% url 'appointments:reservar_cita' %}" class="text-white-50">Reservar Cita</a></li>
-                                <li><a href="{% url 'products:ver_imagenes' %}" class="text-white-50">Productos</a></li>
-                            </ul>
-                        </div>
-            
-                        <!-- LOCATION -->
-                        <div class="col-md-4 text-center">
-                        <h5 class="text-white">Ubicación</h5>
-                        <div class="map-container mb-2">
-                            <iframe
-                            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3490.4957479491627!2d-13.558574623952396!3d28.972677268552072!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xc46276f9ab656d9%3A0x41c1eb89e4d41c84!2sC.%20el%20Rafael%2C%2043%2C%2035500%20Arrecife%2C%20Las%20Palmas!5e0!3m2!1ses!2ses!4v1741366191645!5m2!1ses!2ses"
-                            title="Mapa de la ubicación de Ca’Bigote en Arrecife"
-                            allowfullscreen
-                            loading="lazy"
-                            referrerpolicy="strict-origin-when-cross-origin"
-                            class="w-100 rounded shadow-sm">
-                            </iframe>
-                        </div>
+            <div class="container">
+                <div class="row">
+                <!-- ABOUT -->
+                <div class="col-md-4">
+                    <h5 class="text-white text-center">Sobre Nosotros</h5>
+                    <p>Ca'Bigote es una barbería moderna con un toque clásico. Nos dedicamos a ofrecer los mejores cortes y afeitados con la mejor atención al cliente.</p>
+                </div>
+
+                <!-- ACTIONS -->
+                <div class="col-md-4">
+                    <h5 class="text-white">Enlaces Rápidos</h5>
+                    <ul class="list-unstyled">
+                    <li><a href="{% url 'home' %}" class="text-white-50">Inicio</a></li>
+                    <li><a href="{% url 'services:ver_servicios' %}" class="text-white-50">Servicios</a></li>
+                    <li><a href="{% url 'appointments:reservar_cita' %}" class="text-white-50">Reservar Cita</a></li>
+                    <li><a href="{% url 'products:ver_imagenes' %}" class="text-white-50">Productos</a></li>
+                    <!-- Enlace permanente para abrir el panel de cookies -->
+                    <li><a href="#" class="text-white-50" data-ck-open>Preferencias de cookies</a></li>
+                    </ul>
+                </div>
+
+                <!-- LOCATION -->
+                <div class="col-md-4 text-center">
+                    <h5 class="text-white">Ubicación</h5>
+                    <div class="map-container mb-2">
+                    <!-- Placeholder de mapa bloqueado por consentimiento -->
+                    <div id="gmaps-placeholder"
+                        data-embed-src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3490.4957479491627!2d-13.558574623952396!3d28.972677268552072!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xc46276f9ab656d9%3A0x41c1eb89e4d41c84!2sC.%20el%20Rafael%2C%2043%2C%2035500%20Arrecife%2C%20Las%20Palmas!5e0!3m2!1ses!2ses!4v1741366191645!5m2!1ses!2ses"
+                        class="w-100 rounded shadow-sm">
+                        <div>
+                        <p class="mb-2"><strong>Mapa bloqueado por preferencias de cookies.</strong></p>
+                        <p class="mb-3">Activa “Mapas y terceros” en el panel de configuración para cargar Google Maps.</p>
+                        <button type="button" class="btn btn-info btn-sm" id="enable-maps">Permitir y cargar mapa</button>
                         </div>
                     </div>
-
-                    <!-- VISITOR COUNT -->
-                    <div class="visits-counter-card">
-                        <div class="counter-icon animate-icon">
-                          <i class="fas fa-user-friends"></i>
-                        </div>
-                        <div id="odometer" class="odometer animate-on-load">{{ contador_actualizado|default:contador_global }}</div>
-                        <div class="counter-label">Visitas Totales</div>
-                    </div>                      
-                    
-                    <hr class="border-light">
-
-                    <div class="row mt-3">
-                        <div class="col text-center">
-                            <p class="mb-0">&copy; 2024 Ca´Bigote. Todos los derechos reservados.</p>
-                            <p class="mb-0">
-                                Desarrollado <i class="bi bi-code-slash text-info"></i> por 
-                                <a href="https://josefe.eu.pythonanywhere.com/" target="_blank" class="text-decoration-none fw-bold text-info">JFGC</a>
-                              </p>                              
-                        </div>
                     </div>
-                    <hr class="border-light">
-                    <!-- VERSION -->
+                </div>
+                </div>
+
+                <!-- VISITOR COUNT -->
+                <div class="visits-counter-card">
+                <div class="counter-icon animate-icon">
+                    <i class="fas fa-user-friends"></i>
+                </div>
+                <div id="odometer" class="odometer animate-on-load">{{ contador_actualizado|default:contador_global }}</div>
+                <div class="counter-label">Visitas Totales</div>
+                </div>
+
+                <hr class="border-light">
+
+                <div class="row mt-3">
+                <div class="col text-center">
+                    <p class="mb-0">&copy; 2024 Ca´Bigote. Todos los derechos reservados.</p>
+                    <p class="mb-0">
+                    Desarrollado <i class="bi bi-code-slash text-info"></i> por
+                    <a href="https://josefe.eu.pythonanywhere.com/" target="_blank" class="text-decoration-none fw-bold text-info">JFGC</a>
+                    </p>
+                </div>
+                </div>
+
+                <hr class="border-light">
+
+                <!-- VERSION -->
                 <div class="text-center mt-2">
-                    <small>v{{ APP_VERSION }}</small>
+                <small>v{{ APP_VERSION }}</small>
                 </div>
-                </div>
-            </footer>            
+            </div>
+        </footer>
+      
             
-            <!-- BTN WHATSAPP -->
-            <a
+        <!-- BTN WHATSAPP -->
+        <a id="whatsapp-btn"
             href="https://wa.me/+34659809165"
             target="_blank"
             class="whatsapp-float"
             aria-label="Contactar vía WhatsApp"
-            title="WhatsApp"
-            >
+            title="WhatsApp">
             <i class="fab fa-whatsapp whatsapp-icon"></i>
-            </a>
+        </a>
 
 
+        <!-- Modal de cookies (1ª capa) -->
+        <div id="ck-modal" class="modal fade" tabindex="-1" aria-labelledby="ckm-title" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+            <div class="modal-header">
+                <h5 id="ckm-title" class="modal-title">Tu privacidad es importante</h5>
+                <!-- Si quieres forzar decisión, quita este botón -->
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+
+            <div class="modal-body">
+                <p class="mb-2">
+                Usamos cookies propias (necesarias) y de terceros para funciones como mapas integrados.
+                Puedes <a href="{% url 'home' %}cookies" target="_blank" rel="noopener">leer la política de cookies</a>
+                o <button class="btn btn-link p-0 align-baseline" data-ck-open type="button">configurar</button> tus preferencias.
+                </p>
+                <small class="text-muted">Solo las necesarias están activas por defecto.</small>
+            </div>
+
+            <div class="modal-footer">
+                <button id="ck-reject" class="btn btn-outline-secondary">Solo necesarias</button>
+                <button id="ck-accept" class="btn btn-primary">Aceptar todas</button>
+                <button class="btn btn-ghost" data-ck-open type="button">Configurar</button>
+            </div>
+            </div>
+        </div>
+        </div>
+
+
+        <!-- Panel de configuración (2ª capa) -->
+        <div class="modal fade" id="ck-panel" tabindex="-1" aria-labelledby="ck-title" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content ck-panel">
+            <div class="modal-header py-2">
+                <h5 id="ck-title" class="modal-title">Configuración de cookies</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+
+            <div class="modal-body py-3">
+                <p class="mb-3 ck-note">Solo las <strong>necesarias</strong> están activas por defecto. Ajusta el resto por categorías.</p>
+
+                <ul class="list-group list-group-flush ck-list">
+                <!-- Necesarias -->
+                <li class="list-group-item py-2">
+                    <div class="row align-items-center g-2">
+                    <div class="col">
+                        <div class="d-flex align-items-center flex-wrap gap-2">
+                        <strong class="me-2">Necesarias</strong>
+                        <span class="badge text-bg-secondary ck-badge">Siempre activas</span>
+                        </div>
+                        <div class="text-muted small">Funcionalidad básica del sitio.</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="form-check form-switch m-0">
+                        <input class="form-check-input" type="checkbox" checked disabled>
+                        </div>
+                    </div>
+                    </div>
+                </li>
+
+                <!-- Preferencias -->
+                <li class="list-group-item py-2">
+                    <div class="row align-items-center g-2">
+                    <div class="col">
+                        <strong class="me-2">Preferencias</strong>
+                        <div class="text-muted small">Recordar ajustes de interfaz.</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="form-check form-switch m-0">
+                        <input class="form-check-input" type="checkbox" id="ck-pref">
+                        </div>
+                    </div>
+                    </div>
+                </li>
+
+                <!-- Estadística -->
+                <li class="list-group-item py-2">
+                    <div class="row align-items-center g-2">
+                    <div class="col">
+                        <strong class="me-2">Estadística</strong>
+                        <div class="text-muted small">Medición anónima del uso.</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="form-check form-switch m-0">
+                        <input class="form-check-input" type="checkbox" id="ck-analytics">
+                        </div>
+                    </div>
+                    </div>
+                </li>
+
+                <!-- Marketing -->
+                <li class="list-group-item py-2">
+                    <div class="row align-items-center g-2">
+                    <div class="col">
+                        <strong class="me-2">Marketing</strong>
+                        <div class="text-muted small">Segmentación/seguimiento publicitario.</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="form-check form-switch m-0">
+                        <input class="form-check-input" type="checkbox" id="ck-marketing">
+                        </div>
+                    </div>
+                    </div>
+                </li>
+
+                <!-- Mapas y terceros -->
+                <li class="list-group-item py-2">
+                    <div class="row align-items-center g-2">
+                    <div class="col">
+                        <strong class="me-2">Mapas y terceros</strong>
+                        <div class="text-muted small">Servicios embebidos (Google Maps, Instagram…).</div>
+                    </div>
+                    <div class="col-auto">
+                        <div class="form-check form-switch m-0">
+                        <input class="form-check-input" type="checkbox" id="ck-thirdparty">
+                        </div>
+                    </div>
+                    </div>
+                </li>
+                </ul>
+
+                <details class="mt-3 ck-details">
+                <summary class="small">Ver detalle de cookies y tecnologías</summary>
+                <div class="mt-2 table-responsive ck-table-wrap">
+                    <table class="table table-sm table-bordered mb-0">
+                    <thead class="table-light">
+                        <tr>
+                        <th>Nombre</th><th>Tipo</th><th>Proveedor</th><th>Finalidad</th><th>Duración</th><th>Categoría</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                        <td>ck-consent-v1 (localStorage)</td><td>Propia</td><td>cabigotebarbershop.com</td>
+                        <td>Recordar preferencias de cookies.</td><td>Persistente</td><td>Necesarias</td>
+                        </tr>
+                        <tr>
+                        <td>NID / 1P_JAR / CONSENT (ejemplos)</td><td>Tercero</td><td>google.com (Maps)</td>
+                        <td>Operar y mostrar el mapa embebido.</td><td>Sesión / 6–24 meses</td><td>Mapas y terceros</td>
+                        </tr>
+                    </tbody>
+                    </table>
+                </div>
+                </details>
+            </div>
+
+            <div class="modal-footer py-2">
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button id="ck-save" class="btn btn-primary">Guardar preferencias</button>
+            </div>
+            </div>
+        </div>
+        </div>
+
+
+        <!-- Modal de consentimiento para WhatsApp -->
+        <div id="wa-modal" class="modal fade" tabindex="-1" aria-labelledby="wa-title" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+            <div class="modal-header">
+                <h5 id="wa-title" class="modal-title">Atención por WhatsApp</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+            </div>
+            <div class="modal-body">
+                <p>
+                Para usar el servicio de WhatsApp, acepta la
+                <a href="{% url 'home' %}privacidad" target="_blank" rel="noopener">Política de privacidad</a>
+                y las condiciones del servicio de WhatsApp.
+                </p>
+                <div class="form-check">
+                <input id="wa-accept" class="form-check-input" type="checkbox">
+                <label class="form-check-label" for="wa-accept">
+                    Acepto la política y condiciones del servicio WhatsApp.
+                </label>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="wa-continue" class="btn btn-success" disabled>Continuar a WhatsApp</button>
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+            </div>
+            </div>
+        </div>
+        </div>
+
+        <!-- SCRIPTS -->
         <script src="https://code.jquery.com/jquery-3.6.0.min.js" defer></script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
-        defer></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+
         <script src="https://cdn.jsdelivr.net/npm/jquery-zoom@1.7.21/jquery.zoom.min.js" defer></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/odometer.js/0.4.8/odometer.min.js" defer></script>
 
@@ -327,7 +477,10 @@
 
         <!-- CUSTOM SCRIPTS-->
         <script src="{% static 'js/Loader.js' %}" defer></script>
-        <script src="{% static 'js/Cookies_modal.js' %}" defer></script>
+
+        <script src="{% static 'js/cookiesConsent.js' %}" defer></script>
+        <script src="{% static 'js/whatsappConsent.js' %}" defer></script>
+
         <script src="{% static 'js/Animations.js' %}" defer></script>
         <script src="{% static 'js/historial-citas.js' %}" defer></script>
         <script src="{% static 'js/special_message.js' %}" defer></script>

--- a/core/templates/legal/cookies.html
+++ b/core/templates/legal/cookies.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+{% load static i18n %}
+{% block title %}Política de cookies | Ca’Bigote{% endblock %}
+
+{% block content %}
+<main class="container py-4" id="cookies">
+  <h1 class="mb-3">Política de cookies</h1>
+  <p><strong>Última actualización:</strong> 07/09/2025</p>
+
+  <p>
+    En este sitio (“<strong>Ca’Bigote</strong>”) utilizamos cookies y tecnologías similares para
+    hacer que la web funcione, recordar tus preferencias y, si lo aceptas, habilitar servicios de terceros
+    como mapas integrados. Solo las cookies <strong>necesarias</strong> están activas por defecto.
+  </p>
+
+  <h2 class="h4 mt-4">1. ¿Qué son las cookies?</h2>
+  <p>Son pequeños archivos que el navegador almacena para recordar información técnica, de preferencia o de sesión.</p>
+
+  <h2 class="h4 mt-4">2. ¿Qué tipos usamos?</h2>
+  <ul>
+    <li><strong>Necesarias (propias):</strong> operativa básica del sitio (seguridad, sesión, navegación).</li>
+    <li><strong>Preferencias:</strong> recuerdan ajustes de la interfaz.</li>
+    <li><strong>Estadística:</strong> medición anónima y agregada del uso (solo si la activas).</li>
+    <li><strong>Marketing:</strong> seguimiento/segmentación publicitaria (si se llegara a usar).</li>
+    <li><strong>Mapas y terceros:</strong> servicios embebidos (p. ej., Google Maps, Instagram) que pueden instalar cookies.</li>
+  </ul>
+
+  <h2 class="h4 mt-4">3. Panel de configuración</h2>
+  <p>
+    Puedes cambiar tu elección en cualquier momento desde el
+    <a href="#" data-ck-open>panel de preferencias de cookies</a>.
+  </p>
+
+  <h2 class="h4 mt-4">4. Detalle de cookies concretas</h2>
+
+  <div class="table-responsive">
+    <table class="table table-sm table-bordered">
+      <thead class="thead-light">
+        <tr>
+          <th scope="col">Nombre</th>
+          <th scope="col">Proveedor</th>
+          <th scope="col">Finalidad</th>
+          <th scope="col">Duración</th>
+          <th scope="col">Tipo</th>
+          <th scope="col">Categoría</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Necesarias (Django) -->
+        <tr>
+          <td><code>csrftoken</code></td>
+          <td>Propia (cabigotebarbershop.com)</td>
+          <td>Seguridad CSRF en formularios.</td>
+          <td>~12 meses</td>
+          <td>HTTP</td>
+          <td>Necesarias</td>
+        </tr>
+        <tr>
+          <td><code>sessionid</code></td>
+          <td>Propia (cabigotebarbershop.com)</td>
+          <td>Mantener sesión de usuario autenticado.</td>
+          <td>Sesión</td>
+          <td>HTTP</td>
+          <td>Necesarias</td>
+        </tr>
+        <!-- Preferencias (localStorage, a título informativo) -->
+        <tr>
+          <td><code>ck-consent-v1</code> (localStorage)</td>
+          <td>Propia</td>
+          <td>Recordar tus preferencias de cookies.</td>
+          <td>Persistente</td>
+          <td>LocalStorage</td>
+          <td>Necesarias</td>
+        </tr>
+        <!-- Terceros: Google Maps (solo si activas “Mapas y terceros”) -->
+        <tr>
+          <td>NID / 1P_JAR / CONSENT (ejemplos)</td>
+          <td>Google</td>
+          <td>Operar y mostrar el mapa embebido.</td>
+          <td>Sesión / 6–24 meses</td>
+          <td>HTTP</td>
+          <td>Mapas y terceros</td>
+        </tr>
+        <!-- Añade aquí analytics/ads si los incorporas más adelante -->
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="h4 mt-4">5. ¿Cómo cambiar o retirar el consentimiento?</h2>
+  <ul>
+    <li>Desde el <a href="#" data-ck-open>panel de preferencias</a>.</li>
+    <li>Desde tu navegador (eliminando cookies o bloqueándolas). Consulta la ayuda de tu navegador.</li>
+  </ul>
+
+  <h2 class="h4 mt-4">6. Terceros y transferencias</h2>
+  <p>
+    El uso de servicios de terceros (p. ej., Google Maps o Instagram) puede implicar transferencias internacionales.
+    Revisa sus políticas para más información:
+    <a href="https://policies.google.com/technologies/cookies?hl=es" target="_blank" rel="noopener">Google</a>,
+    <a href="https://privacycenter.instagram.com/policy/?entry_point=ig_help_center_data_policy_redirect" target="_blank" rel="noopener">Instagram</a>.
+  </p>
+
+  <h2 class="h4 mt-4">7. Actualizaciones</h2>
+  <p>Podemos actualizar esta política para reflejar cambios legales o técnicos. Te recomendamos revisarla periódicamente.</p>
+</main>
+{% endblock %}

--- a/core/templates/legal/privacidad.html
+++ b/core/templates/legal/privacidad.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% load static i18n %}
+{% block title %}Política de privacidad | Ca’Bigote{% endblock %}
+
+{% block content %}
+<main class="container py-4" id="privacidad">
+  <h1 class="mb-3">Política de privacidad</h1>
+  <p><strong>Última actualización:</strong> 07/09/2025</p>
+
+  <h2 class="h4 mt-4">1. Responsable del tratamiento</h2>
+  <p>
+    <strong>Nombre comercial:</strong> Ca’Bigote Barbershop<br>
+    <strong>Razón social / CIF:</strong> <em>RELLENAR_RAZÓN_SOCIAL</em> — <em>RELLENAR_CIF</em><br>
+    <strong>Domicilio:</strong> C. el Rafael, 43, 35500 Arrecife, Las Palmas (España)<br>
+    <strong>Correo de contacto:</strong> <a href="mailto:RELLENAR_EMAIL">RELLENAR_EMAIL</a><br>
+    <strong>Web:</strong> cabigotebarbershop.com
+  </p>
+
+  <h2 class="h4 mt-4">2. Datos, finalidades y bases jurídicas</h2>
+  <ul>
+    <li><strong>Reservas de cita / cuenta de usuario:</strong> identificación y contacto (nombre, email, teléfono), credenciales si te registras.
+      <br><em>Finalidad:</em> gestionar citas y tu cuenta.<br>
+      <em>Base legal:</em> ejecución de contrato/medidas precontractuales (art. 6.1.b RGPD).</li>
+    <li><strong>Consultas generales (formularios/email):</strong> datos de contacto y el contenido de tu consulta.
+      <br><em>Finalidad:</em> atender la solicitud y hacer seguimiento.<br>
+      <em>Base legal:</em> consentimiento (art. 6.1.a) y/o interés legítimo (art. 6.1.f) según el caso.</li>
+    <li><strong>Atención por WhatsApp (opcional):</strong> identificación y comunicaciones.
+      <br><em>Finalidad:</em> soporte/comunicación por WhatsApp a petición del usuario.<br>
+      <em>Base legal:</em> consentimiento (art. 6.1.a). Puede implicar transferencias por parte de Meta.</li>
+    <li><strong>Seguridad del sitio:</strong> datos técnicos (IP, logs, user-agent).
+      <br><em>Finalidad:</em> mantener la seguridad y prevenir abusos.<br>
+      <em>Base legal:</em> interés legítimo (art. 6.1.f).</li>
+    <!-- Si más adelante añades newsletter/ads, añade aquí Marketing con base 6.1.a -->
+  </ul>
+
+  <h2 class="h4 mt-4">3. Conservación</h2>
+  <ul>
+    <li>Consultas: hasta <strong>12 meses</strong> desde la última interacción.</li>
+    <li>Reservas y relación con clientes: mientras dure el servicio y hasta <strong>24 meses</strong> tras su fin (o plazos legales).</li>
+    <li>Cuentas: mientras permanezcan activas (y según obligaciones legales).</li>
+    <li>Datos técnicos/logs: hasta <strong>12 meses</strong>.</li>
+  </ul>
+
+  <h2 class="h4 mt-4">4. Destinatarios</h2>
+  <p>
+    Podrán acceder proveedores que nos prestan servicios (alojamiento web, soporte TI, mensajería), bajo contrato de encargo de tratamiento.
+    El uso de <strong>Google Maps</strong>/Instagram (si lo aceptas) conlleva que dichos terceros puedan tratar datos conforme a sus políticas.
+  </p>
+
+  <h2 class="h4 mt-4">5. Transferencias internacionales</h2>
+  <p>
+    Algunos proveedores pueden estar ubicados fuera del EEE (p. ej., Google/Meta). Se usarán garantías adecuadas (p. ej., cláusulas contractuales tipo) cuando aplique.
+    Más información en sus políticas: Google, Meta/Instagram/WhatsApp.
+  </p>
+
+  <h2 class="h4 mt-4">6. Derechos de las personas</h2>
+  <p>
+    Puedes ejercer tus derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad enviando un correo a
+    <a href="mailto:RELLENAR_EMAIL">RELLENAR_EMAIL</a> con el asunto “Protección de datos” y acreditando tu identidad.
+    Si consideras que no se han atendido correctamente tus derechos, puedes reclamar ante la Agencia Española de Protección de Datos (AEPD).
+  </p>
+
+  <h2 class="h4 mt-4">7. Menores</h2>
+  <p>Los servicios no están dirigidos específicamente a menores. Si detectamos datos de menores sin autorización, procederemos a su eliminación.</p>
+
+  <h2 class="h4 mt-4">8. Seguridad</h2>
+  <p>Aplicamos medidas técnicas y organizativas razonables para proteger los datos frente a accesos no autorizados, pérdida o alteración.</p>
+
+  <h2 class="h4 mt-4">9. Cookies y terceros</h2>
+  <p>
+    Para conocer el uso de cookies y cómo configurarlas o revocar tu consentimiento, consulta la
+    <a href="{% url 'home' %}cookies">Política de cookies</a> o abre el
+    <a href="#" data-ck-open>panel de preferencias</a>.
+  </p>
+
+  <h2 class="h4 mt-4">10. Cambios en la política</h2>
+  <p>Podemos actualizar esta política para reflejar cambios legales o técnicos. Publicaremos la nueva versión con su fecha de actualización.</p>
+</main>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
+from django.views.generic import TemplateView
 from .views import lanzar_recordatorios
 
 urlpatterns = [
     path('lanzar-recordatorios/', lanzar_recordatorios, name='lanzar_recordatorios'),
+    path("cookies/",    TemplateView.as_view(template_name="legal/cookies.html"),    name="cookies"),
+    path("privacidad/", TemplateView.as_view(template_name="legal/privacidad.html"), name="privacidad"),
 ]

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -198,9 +198,35 @@ footer a:hover { color: var(--link-hover-background);}
 #cookiesPolicyLink {  padding-top: 1rem; padding-bottom: 1rem;}
 
 /* Estilo para la ubicación */
-.map-container { position: relative; overflow: hidden; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15); width: 100%;    padding-bottom: 56.25%; background-color: #f5f5f5; margin-top: 1rem;       }
+.map-container{ position: relative; overflow: hidden; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,.15); width: 100%; padding-bottom: 56.25%; background-color: #0b0f14; margin-top: 1rem;}
 
-.map-container iframe { position: absolute; top: 0; left: 0; width: 100%;  height: 100%; border: none; border-radius: 8px;}
+/* Iframe ocupa todo el contenedor */
+.map-container iframe{
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  border: none; border-radius: 8px;
+}
+
+/* Placeholder (bloqueado) ocupa todo el contenedor igual que el iframe */
+#gmaps-placeholder{
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border-radius: 8px;
+  border: 2px solid rgba(255,255,255,.2);
+  color: #e6eef7;
+  text-align: center;
+}
+
+/* Botón del placeholder */
+#gmaps-placeholder .btn{
+  margin-top: .5rem;
+}
+
 
 /* Estilo para el botón flotante */
 .whatsapp-float {position: fixed;width: 60px;height: 60px;bottom: 20px;right: 20px;background-color: #25d366;color: white;border-radius: 50%;text-align: center;font-size: 30px;z-index: 1000;box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);transition: transform 0.3s ease, box-shadow 0.3s ease;}

--- a/static/js/cookiesConsent.js
+++ b/static/js/cookiesConsent.js
@@ -1,0 +1,172 @@
+/* cookiesConsent.js — Ca'Bigote (modal 1ª capa + panel 2ª capa) */
+(function () {
+  const KEY = 'ck-consent-v1';
+
+  // 1ª capa (modal centrado). Si no existe, usaremos banner como fallback (no lo estás usando ya).
+  const firstLayerEl = document.getElementById('ck-modal');
+  const firstLayer   = () => firstLayerEl ? bootstrap.Modal.getOrCreateInstance(firstLayerEl, { backdrop: 'static', keyboard: false }) : null;
+  const banner       = document.getElementById('ck-banner'); // por si lo dejas en alguna página
+
+  // Panel 2ª capa
+  const panelEl = document.getElementById('ck-panel');
+  const panel   = () => bootstrap.Modal.getOrCreateInstance(panelEl);
+
+  const q = sel => document.querySelector(sel);
+  const getVersion = () =>
+    document.querySelector('meta[name="application-version"]')?.content || '1.0';
+
+  const defaultConsent = () => ({
+    necessary: true,
+    preferences: false,
+    analytics: false,
+    marketing: false,
+    thirdparty: false,
+    ts: new Date().toISOString(),
+    version: getVersion()
+  });
+
+  const readConsent = () => {
+    try { return JSON.parse(localStorage.getItem(KEY)) || null; }
+    catch { return null; }
+  };
+
+  const saveConsent = (obj) => {
+    const data = { ...defaultConsent(), ...obj, ts: new Date().toISOString(), version: getVersion() };
+    localStorage.setItem(KEY, JSON.stringify(data));
+    applyConsent(data);
+    return data;
+  };
+
+  // Mostrar 1ª capa si no hay consentimiento previo
+  const showFirstLayerIfNeeded = () => {
+    if (readConsent()) return;
+    if (firstLayerEl) firstLayer()?.show();
+    else if (banner) banner.removeAttribute('hidden');
+  };
+
+  const openPanel = (e) => {
+    e?.preventDefault?.();
+    // si el modal de 1ª capa está abierto, ciérralo antes de abrir 2ª capa
+    if (firstLayerEl && firstLayerEl.classList.contains('show')) {
+      firstLayer()?.hide();
+    } else if (banner && !banner.hasAttribute('hidden')) {
+      banner.setAttribute('hidden', '');
+    }
+
+    const c = readConsent() || defaultConsent();
+    // sincroniza switches
+    q('#ck-pref').checked       = !!c.preferences;
+    q('#ck-analytics').checked  = !!c.analytics;
+    q('#ck-marketing').checked  = !!c.marketing;
+    q('#ck-thirdparty').checked = !!c.thirdparty;
+    panel().show();
+  };
+
+  // ====== APLICAR CONSENTIMIENTO EN LA PÁGINA ======
+  const applyConsent = (c) => {
+    handleMap(c.thirdparty);
+
+    // (Opcional) gatear Instagram embed
+    if (c.thirdparty) loadInstagram();
+    else removeInstagram();
+
+    // TODO futuro: cargar analytics/pixel sólo si c.analytics / c.marketing
+  };
+
+  // ====== MAPS LOADER ======
+  const handleMap = (allow) => {
+    const ph = document.getElementById('gmaps-placeholder');
+    if (!ph) return;
+
+    const iframeExists = ph.querySelector('iframe');
+    if (allow && !iframeExists) {
+      const src = ph.getAttribute('data-embed-src');
+      if (!src) return;
+      const iframe = document.createElement('iframe');
+      iframe.src = src;
+      iframe.title = 'Mapa de la ubicación';
+      iframe.loading = 'lazy';
+      iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+      iframe.allowFullscreen = true;
+      iframe.style.width = '100%';
+      iframe.style.height = '260px';
+      iframe.className = 'rounded shadow-sm';
+      ph.innerHTML = '';
+      ph.appendChild(iframe);
+    }
+    if (!allow && iframeExists) {
+      ph.innerHTML = `
+        <div>
+          <p class="mb-2"><strong>Mapa bloqueado por preferencias de cookies.</strong></p>
+          <p class="mb-3">Activa “Mapas y terceros” para cargar Google Maps.</p>
+          <button type="button" class="btn btn-info btn-sm" id="enable-maps">Permitir y cargar mapa</button>
+        </div>`;
+    }
+  };
+
+  // ====== Instagram embed (opcional) ======
+  const loadInstagram = () => {
+    if (document.getElementById('ig-embed-js')) return;
+    const s = document.createElement('script');
+    s.id = 'ig-embed-js';
+    s.async = true;
+    s.src = 'https://www.instagram.com/embed.js';
+    document.body.appendChild(s);
+  };
+  const removeInstagram = () => {
+    const s = document.getElementById('ig-embed-js');
+    if (s) s.remove();
+  };
+
+  // ====== EVENTOS UI ======
+  document.addEventListener('click', (e) => {
+    const openBtn = e.target.closest('[data-ck-open]');
+    if (openBtn) openPanel(e);
+  });
+
+  // aceptar/rechazar (IDs compartidos en modal o banner)
+  const onAccept = () => {
+    saveConsent({ preferences: true, analytics: true, marketing: true, thirdparty: true });
+    firstLayer()?.hide();
+    banner?.setAttribute('hidden', '');
+  };
+  const onReject = () => {
+    saveConsent({ preferences: false, analytics: false, marketing: false, thirdparty: false });
+    firstLayer()?.hide();
+    banner?.setAttribute('hidden', '');
+  };
+
+  q('#ck-accept')?.addEventListener('click', onAccept);
+  q('#ck-reject')?.addEventListener('click', onReject);
+
+  // Guardar desde 2ª capa
+  q('#ck-save')?.addEventListener('click', () => {
+    const newC = {
+      preferences: q('#ck-pref')?.checked || false,
+      analytics:  q('#ck-analytics')?.checked || false,
+      marketing:  q('#ck-marketing')?.checked || false,
+      thirdparty: q('#ck-thirdparty')?.checked || false
+    };
+    saveConsent(newC);
+    panel().hide();
+    firstLayer()?.hide();
+    banner?.setAttribute('hidden', '');
+  });
+
+  // botón “Permitir y cargar mapa” directo
+  document.addEventListener('click', (e) => {
+    if (e.target && e.target.id === 'enable-maps') {
+      e.preventDefault();
+      const c = readConsent() || defaultConsent();
+      c.thirdparty = true;
+      saveConsent(c);
+    }
+  });
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    const c = readConsent();
+    if (c) applyConsent(c);
+    showFirstLayerIfNeeded();
+  });
+})();

--- a/static/js/whatsappConsent.js
+++ b/static/js/whatsappConsent.js
@@ -1,0 +1,35 @@
+/* whatsappConsent.js — Ca'Bigote */
+(function () {
+  const waBtn = document.getElementById('whatsapp-btn');
+  const modalEl = document.getElementById('wa-modal');
+  if (!waBtn || !modalEl) return;
+
+  const modal = () => bootstrap.Modal.getOrCreateInstance(modalEl);
+  const checkbox = modalEl.querySelector('#wa-accept');
+  const continueBtn = modalEl.querySelector('#wa-continue');
+
+  // Habilita/deshabilita el botón de continuar según el checkbox
+  checkbox?.addEventListener('change', () => {
+    continueBtn.disabled = !checkbox.checked;
+  });
+
+  // Intercepta el click del botón flotante
+  waBtn.addEventListener('click', (e) => {
+    // Si ya aceptó previamente en esta sesión, deja pasar:
+    if (sessionStorage.getItem('wa-accepted') === '1') return;
+    e.preventDefault();
+    // Abre modal
+    checkbox.checked = false;
+    continueBtn.disabled = true;
+    modal().show();
+  });
+
+  // Continuar a WhatsApp
+  continueBtn.addEventListener('click', () => {
+    const href = waBtn.getAttribute('href');
+    sessionStorage.setItem('wa-accepted', '1');
+    modal().hide();
+    // Redirige
+    window.open(href, '_blank', 'noopener');
+  });
+})();


### PR DESCRIPTION
…or maps and instagram

- Replace cookie banner with a modal based first layer using Bootstrap 5 modal
- Keep second layer panel, realign with rows and form switches, reduce padding and cap body height to avoid page scroll
- Persist consent in localStorage key ck-consent-v1 including app version and timestamp
- Gate Google Maps iframe and Instagram embed behind thirdparty category and apply changes live on save
- Add WhatsApp consent modal before wa.me, remembered per session via sessionStorage
- Update links to open preferences via data-ck-open and use Django named routes cookies and privacidad
- Add legal pages templates legal/cookies.html and legal/privacidad.html with TemplateView routes
- Align Bootstrap to 5.3.3 CSS and JS, remove legacy v4 CSS and old cookie modals and script
- Minor styles for compact panel and map placeholder

refs: RGPD compliance and UX polish for Ca Bigote